### PR TITLE
Remove Elixir warnings

### DIFF
--- a/lib/codepagex.ex
+++ b/lib/codepagex.ex
@@ -33,7 +33,7 @@ defmodule Codepagex do
   end
 
   format_helper = fn {a, m} ->
-    "  | #{inspect(a) |> String.ljust(15)} | #{m} |"
+    "  | #{inspect(a) |> String.pad_trailing(15)} | #{m} |"
   end
 
   @aliases_markdown (
@@ -66,7 +66,7 @@ defmodule Codepagex do
   @encodings_markdown (
     # format as table with 3 columns
     Mappings.encoding_list(:all)
-    |> Enum.map(&(String.ljust(&1, 30)))
+    |> Enum.map(&(String.pad_trailing(&1, 30)))
     |> Enum.chunk(3, 3, ["", ""])
     |> Enum.map(&(Enum.join(&1, " | ")))
     |> Enum.map(&("| #{&1} |"))


### PR DESCRIPTION
In Elixir 1.5.2 (at least) some deprecation warnings are show:

```
==> codepagex
Compiling 6 files (.ex)
warning: String.ljust/2 is deprecated, use String.pad_trailing/2
  lib/codepagex.ex:36

warning: String.ljust/2 is deprecated, use String.pad_trailing/2
  lib/codepagex.ex:69
```

and this patch should fix them.