### PR TITLE
Do not use Keyword.keys when data isn't a keyword list

### DIFF
--- a/lib/codepagex/mappings.ex
+++ b/lib/codepagex/mappings.ex
@@ -176,7 +176,7 @@ defmodule Codepagex.Mappings do
   # These are documented in Codepagex.encoding_list/1
   def encoding_list(selection \\ nil)
   def encoding_list(:all), do: @all_names_files |> Map.keys |> Enum.sort
-  def encoding_list(_), do: @filtered_names_files |> Keyword.keys |> Enum.sort
+  def encoding_list(_), do: @filtered_names_files |> Enum.into(%{}) |> Map.keys |> Enum.sort
 
   # load mapping files
   @encodings (for {name, file} <- @filtered_names_files,


### PR DESCRIPTION
The key isn't an atom, but a binary, that doesn't work well in Elixir 1.11.0-dev.

```elixir
# Interactive Elixir (1.10.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Keyword.keys([{"a", 1}])
["a"]
```
```elixir
# Interactive Elixir (1.11.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Keyword.keys([{"a", 1}])
** (ArgumentError) expected a keyword list, but an entry in the list is not a two-element tuple with an atom as its first element, got: {"a", 1}
    (elixir 1.11.0-dev) lib/keyword.ex:457: Keyword.keys/1
```

I've tried to compile my app in Elixir 1.11.0-dev (still not released) and couldn't compile this `codepagex` dependency.