### PR TITLE
Mark clauses as generated to remove warnings

### DIFF
--- a/lib/codepagex/mappings.ex
+++ b/lib/codepagex/mappings.ex
@@ -17,7 +17,7 @@ defmodule Codepagex.Mappings.Helpers do
   end
 
   defmacro def_to_string(name, encoding) do
-    quote(bind_quoted: [n: name, e: encoding], unquote: false) do
+    quote(bind_quoted: [n: name, e: encoding], generated: true, unquote: false) do
       alias Codepagex.Mappings.Helpers
       fn_name = Helpers.function_name_for_mapping_name("to_string", n)
 
@@ -71,7 +71,7 @@ defmodule Codepagex.Mappings.Helpers do
   end
 
   defmacro def_from_string(name, encoding) do
-    quote(bind_quoted: [n: name, e: encoding], unquote: false) do
+    quote(bind_quoted: [n: name, e: encoding], generated: true, unquote: false) do
       alias Codepagex.Mappings.Helpers
       fn_name = Helpers.function_name_for_mapping_name("from_string", n)
 


### PR DESCRIPTION
This PR marks the generated clauses as generated to remove warnings during compilation.

>    warning: this clause cannot match because a previous clause at line 210 always matches
>    └─ lib/codepagex/mappings.ex:210

Solves #21. Would be great if a new version can be released after merge. 🙏 