### PR TITLE
Divide function clause building in a single module per encoding

### DIFF
--- a/dev/mix/tasks/codepagex/benchee.ex
+++ b/dev/mix/tasks/codepagex/benchee.ex
@@ -7,6 +7,10 @@ defmodule Mix.Tasks.Codepagex.Benchee do
   require Codepagex
 
   @iso from_string!("æøåæøåæøåæøåæøåÆØÅÆØÅÆØÅÆØÅÆØÅabcdefghijlm", :iso_8859_1)
+  @iso_gigantic from_string!(
+                  Stream.cycle(["Æ"]) |> Stream.take(1 * 1000 * 1000) |> Enum.into(""),
+                  :iso_8859_1
+                )
   @ascii from_string!("abcdefghijklmnopqrstuvwxyzABCDEFGHIJK", :ascii)
   @utf8 "abcdefghijklmnoÆØÅæøåABCDEFGæøåæøåæøåæøåæøåæøåæøåæøå"
   @utf8_gigantic Stream.cycle(["A"]) |> Stream.take(1 * 1000 * 1000) |> Enum.into("")
@@ -16,6 +20,7 @@ defmodule Mix.Tasks.Codepagex.Benchee do
     tests = %{
       ascii_to_string: &ascii_to_string/0,
       iso_to_string: &iso_to_string/0,
+      gigantic_iso_to_string: &gigantic_iso_to_string/0,
       ascii_from_string: &ascii_from_string/0,
       ascii_from_gigantic_string: &ascii_from_gigantic_string/0,
       iso_from_string: &iso_from_string/0,
@@ -27,27 +32,31 @@ defmodule Mix.Tasks.Codepagex.Benchee do
   end
 
   defp ascii_to_string do
-    for _ <- 1..1000, do: to_string(@ascii, :ascii)
+    for _ <- 1..1000, do: to_string!(@ascii, :ascii)
+  end
+
+  defp gigantic_iso_to_string do
+    for _ <- 1..1000, do: to_string!(@iso_gigantic, :iso_8859_1)
   end
 
   defp iso_to_string do
-    for _ <- 1..1000, do: to_string(@iso, :iso_8859_1)
+    for _ <- 1..1000, do: to_string!(@iso, :iso_8859_1)
   end
 
   defp ascii_from_string do
-    for _ <- 1..1000, do: from_string(@utf8, :ascii, replace_nonexistent("_"))
+    for _ <- 1..1000, do: from_string!(@utf8, :ascii, replace_nonexistent("_"))
   end
 
   defp ascii_from_gigantic_string do
-    for _ <- 1..1000, do: from_string(@utf8_gigantic, :ascii, replace_nonexistent("_"))
+    for _ <- 1..1000, do: from_string!(@utf8_gigantic, :ascii, replace_nonexistent("_"))
   end
 
   defp iso_from_string do
-    for _ <- 1..1000, do: from_string(@utf8, :iso_8859_1)
+    for _ <- 1..1000, do: from_string!(@utf8, :iso_8859_1)
   end
 
   defp iso_from_gigantic_string do
-    for _ <- 1..1000, do: from_string(@utf8_gigantic, :iso_8859_1)
+    for _ <- 1..1000, do: from_string!(@utf8_gigantic, :iso_8859_1)
   end
 
   defp erlang_unicode_from_gigantic_string do

--- a/lib/codepagex/mappings.ex
+++ b/lib/codepagex/mappings.ex
@@ -19,12 +19,12 @@ defmodule Codepagex.Mappings.Helpers do
       for encoding_point <- e do
         case encoding_point do
           {from, to} ->
-            def to_string(
-                  unquote(from) <> rest,
-                  acc,
-                  missing_fun,
-                  outer_acc
-                ) do
+            defp to_string(
+                   unquote(from) <> rest,
+                   acc,
+                   missing_fun,
+                   outer_acc
+                 ) do
               to_string(
                 rest,
                 acc <> <<unquote(to)::utf8>>,
@@ -35,11 +35,11 @@ defmodule Codepagex.Mappings.Helpers do
         end
       end
 
-      def to_string("", result, _, outer_acc) do
+      defp to_string("", result, _, outer_acc) do
         {:ok, result, outer_acc}
       end
 
-      def to_string(rest, acc, missing_fun, outer_acc) do
+      defp to_string(rest, acc, missing_fun, outer_acc) do
         case missing_fun.(rest, outer_acc) do
           res = {:error, _, _} ->
             res
@@ -63,22 +63,22 @@ defmodule Codepagex.Mappings.Helpers do
       for encoding_point <- e do
         case encoding_point do
           {from, to} ->
-            def from_string(
-                  <<unquote(to)::utf8>> <> rest,
-                  acc,
-                  fun,
-                  outer_acc
-                ) do
+            defp from_string(
+                   <<unquote(to)::utf8>> <> rest,
+                   acc,
+                   fun,
+                   outer_acc
+                 ) do
               from_string(rest, acc <> unquote(from), fun, outer_acc)
             end
         end
       end
 
-      def from_string("", result, _, outer_acc) do
+      defp from_string("", result, _, outer_acc) do
         {:ok, result, outer_acc}
       end
 
-      def from_string(rest, acc, missing_fun, outer_acc) do
+      defp from_string(rest, acc, missing_fun, outer_acc) do
         case missing_fun.(rest, outer_acc) do
           res = {:error, _, _} ->
             res
@@ -192,6 +192,14 @@ defmodule Codepagex.Mappings do
           require Codepagex.Mappings.Helpers
           alias Codepagex.Mappings.Helpers
 
+          def to_string(binary, missing_fun, acc) do
+            to_string(binary, <<>>, missing_fun, acc)
+          end
+
+          def from_string(binary, missing_fun, acc) do
+            from_string(binary, <<>>, missing_fun, acc)
+          end
+
           Helpers.def_to_string(name, encodings)
           Helpers.def_from_string(name, encodings)
         end
@@ -207,11 +215,11 @@ defmodule Codepagex.Mappings do
     module_name = Helpers.module_name_for_mapping_name(name)
 
     def to_string(binary, unquote(name |> String.to_atom()), missing_fun, acc) do
-      unquote(module_name).to_string(binary, <<>>, missing_fun, acc)
+      unquote(module_name).to_string(binary, missing_fun, acc)
     end
 
     def from_string(binary, unquote(name |> String.to_atom()), missing_fun, acc) do
-      unquote(module_name).from_string(binary, <<>>, missing_fun, acc)
+      unquote(module_name).from_string(binary, missing_fun, acc)
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/tallakt/codepagex/issues/33

This will improve compilation memory usage heavily, since instead of loading all function clauses into a single module, we only need to have each encoding's function clauses in memory at once. So now, the max memory usage will be the largest encoding requested by the user instead of the sum of all encodings.